### PR TITLE
#3 기본 라우트 추가

### DIFF
--- a/src/pages/me/meetup/_meetup.vue
+++ b/src/pages/me/meetup/_meetup.vue
@@ -1,0 +1,15 @@
+<template>
+  <div>
+    <h1>Meetup details</h1>
+  </div>
+</template>
+
+<script>
+export default {
+
+}
+</script>
+
+<style>
+
+</style>

--- a/src/pages/me/meetup/index.vue
+++ b/src/pages/me/meetup/index.vue
@@ -1,0 +1,15 @@
+<template>
+  <div>
+    <h1>My Meetups</h1>
+  </div>
+</template>
+
+<script>
+export default {
+
+}
+</script>
+
+<style>
+
+</style>

--- a/src/pages/meetup/_meetup/attendee.vue
+++ b/src/pages/meetup/_meetup/attendee.vue
@@ -1,0 +1,15 @@
+<template>
+  <div>
+    <h1>Meetup attendees</h1>
+  </div>
+</template>
+
+<script>
+export default {
+
+}
+</script>
+
+<style>
+
+</style>

--- a/src/pages/meetup/_meetup/index.vue
+++ b/src/pages/meetup/_meetup/index.vue
@@ -1,0 +1,15 @@
+<template>
+  <div>
+    <h1>Meetup Details</h1>
+  </div>
+</template>
+
+<script>
+export default {
+
+}
+</script>
+
+<style>
+
+</style>

--- a/src/pages/meetup/index.vue
+++ b/src/pages/meetup/index.vue
@@ -1,0 +1,15 @@
+<template>
+  <div>
+    <h1>Meetups</h1>
+  </div>
+</template>
+
+<script>
+export default {
+
+}
+</script>
+
+<style>
+
+</style>

--- a/src/pages/organize/index.vue
+++ b/src/pages/organize/index.vue
@@ -1,0 +1,15 @@
+<template>
+  <div>
+    <h1>Organize</h1>
+  </div>
+</template>
+
+<script>
+export default {
+
+}
+</script>
+
+<style>
+
+</style>

--- a/src/pages/organize/meetup/_meetup.vue
+++ b/src/pages/organize/meetup/_meetup.vue
@@ -1,0 +1,15 @@
+<template>
+  <div>
+    <h1>Organized meetup details</h1>
+  </div>
+</template>
+
+<script>
+export default {
+
+}
+</script>
+
+<style>
+
+</style>

--- a/src/pages/organize/new.vue
+++ b/src/pages/organize/new.vue
@@ -1,0 +1,15 @@
+<template>
+  <div>
+    <h1>New Meetup</h1>
+  </div>
+</template>
+
+<script>
+export default {
+
+}
+</script>
+
+<style>
+
+</style>


### PR DESCRIPTION
이슈 #3 에서 나온 라우트 목록입니다 `organize` 관련 라우트는 필요할만한 내용 추가했습니다

사실 `nuxt-child` 로 풀어야할 라우트가 있어보이는데 의견을 듣고 싶습니다

현재까지 라우트 내용입니다

```
    routes: [
		{
			path: "/",
			component: _ba124cb6,
			name: "index"
		},
		{
			path: "/organize",
			component: _33035ae2,
			name: "organize"
		},
		{
			path: "/meetup",
			component: _5034fcc3,
			name: "meetup"
		},
		{
			path: "/organize/new",
			component: _4076faa0,
			name: "organize-new"
		},
		{
			path: "/me/meetup",
			component: _27de31aa,
			name: "me-meetup"
		},
		{
			path: "/me/meetup/:meetup",
			component: _c0cb264c,
			name: "me-meetup-meetup"
		},
		{
			path: "/organize/meetup/:meetup?",
			component: _34ad556f,
			name: "organize-meetup-meetup"
		},
		{
			path: "/meetup/:meetup",
			component: _0c6553d0,
			name: "meetup-meetup"
		},
		{
			path: "/meetup/:meetup/attendee",
			component: _03c41f2c,
			name: "meetup-meetup-attendee"
		}
    ],
```